### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,8 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,.gitignore,.gitattributes,*.svg,.codespellrc
+skip = .git,.git-meta,.gitignore,.gitattributes,*.svg,.codespellrc
 check-hidden = true
 ignore-regex = ^\s*"image/\S+": ".*
-# ignore-words-list =
+ignore-words-list =
+  # valid biology term used in NOR_gate example (inactivate the Promoter)
+  inactivate

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.gitignore,.gitattributes,*.svg,.codespellrc
+check-hidden = true
+ignore-regex = ^\s*"image/\S+": ".*
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The reaction above is a death reaction where the meta-species Mortal is dying. `
 
 In the code above, one can visualize the inheritance mechanism. Here both Replicator and Triplicator inherit from Mortal. Therefore, they also receive a death reaction. Multiplicator inherits from Replicator and Triplicator, and therefore from Mortal too. So Multiplicator now has three reactions, the death reaction, the duplication reaction, and the triplication reaction. 
 
-## Indepedent State Spaces
+## Independent State Spaces
 
 Each meta-species has a set of states. One can add states to species by using the dot command (`.state`) or by inheritance. A meta-species that inherits from another gains access to its states. 
 For instance:

--- a/docs/example_models/journal_models/Synchronized_Cycles_of_Bacterial_Lysis.py
+++ b/docs/example_models/journal_models/Synchronized_Cycles_of_Bacterial_Lysis.py
@@ -49,7 +49,7 @@ import os
     12 / u.h,
 )
 
-# N, L, H, I - Are the respective conterparts of the meta-species below
+# N, L, H, I - Are the respective counterparts of the meta-species below
 # in the original paper's model
 Cell, Lysis, AHL, LuxI = BaseSpecies()
 

--- a/docs/example_models/tutorial_notebooks/01_Basic_Intro.ipynb
+++ b/docs/example_models/tutorial_notebooks/01_Basic_Intro.ipynb
@@ -176,7 +176,7 @@
     "Mortal = BaseSpecies()\n",
     "\n",
     "# Functions can be rates. Reactants will be passed to the function which will return a higher rate if it contains the\n",
-    "# charcteristic old\n",
+    "# characteristic old\n",
     "Mortal >> Zero[lambda r1: 1 / u.year if r1.old else 0]"
    ]
   },
@@ -233,7 +233,7 @@
     "`Tree.young.yellow.dense` $\\rightarrow$ `Tree.old.yellow.dense` \\\n",
     "`Tree.young.yellow.sparse` $\\rightarrow$ `Tree.old.yellow.sparse` \n",
     "\n",
-    "When using the dot notation in the reactants, MobsPy performs a query and filters the states that do not contain the specified characteristics. When using the dot notation in the products, one specifies the coordinate on the vector space where the transformation should occur. Thus, the Ager reaction transforms young to old as those are the characteritics in the Ager vector axis."
+    "When using the dot notation in the reactants, MobsPy performs a query and filters the states that do not contain the specified characteristics. When using the dot notation in the products, one specifies the coordinate on the vector space where the transformation should occur. Thus, the Ager reaction transforms young to old as those are the characteristics in the Ager vector axis."
    ]
   },
   {
@@ -279,7 +279,7 @@
     "Further, the second reactant becomes the second product unless there are more products than reactants. \n",
     "In that case, if the products run out of corresponding reactants, MobsPy will cycle through the reactants and pick the first one again.\n",
     "\n",
-    "See the diagram bellow for the reaction\n",
+    "See the diagram below for the reaction\n",
     "\n",
     "```python\n",
     "2 * Meta_species_1 + Meta_species_2 >> 3 * Meta_species_1 + Meta_species_2\n",
@@ -499,7 +499,7 @@
    "metadata": {},
    "source": [
     "One can see how MobsPy was able to reduce a 27 reaction model into three meta-reactions. \n",
-    "Finally, one can acess the results inside the simulation object "
+    "Finally, one can access the results inside the simulation object "
    ]
   },
   {

--- a/docs/example_models/tutorial_notebooks/09_Result_Data.ipynb
+++ b/docs/example_models/tutorial_notebooks/09_Result_Data.ipynb
@@ -138,7 +138,7 @@
    "metadata": {},
    "source": [
     "One can also access the data directly from the simulation object using the meta-species objects or strings. \n",
-    "Similarly to the plotting function you can perform queries in the result data. Below, we show an example to acess the data directly:"
+    "Similarly to the plotting function you can perform queries in the result data. Below, we show an example to access the data directly:"
    ]
   },
   {

--- a/docs/example_models/tutorial_notebooks/11_Looping_Through_Species.ipynb
+++ b/docs/example_models/tutorial_notebooks/11_Looping_Through_Species.ipynb
@@ -130,7 +130,7 @@
    "source": [
     "## List Species\n",
     "\n",
-    "Futhermore, MobsPy provides a `ListSpecies` constructor. This constructor creates a list of meta-species automatically named with the variable used to construct the `ListSpecies`, concatenated with `_` and the number of the species in the list."
+    "Furthermore, MobsPy provides a `ListSpecies` constructor. This constructor creates a list of meta-species automatically named with the variable used to construct the `ListSpecies`, concatenated with `_` and the number of the species in the list."
    ]
   },
   {

--- a/docs/example_models/tutorial_notebooks/18_Reversible_Reactions.ipynb
+++ b/docs/example_models/tutorial_notebooks/18_Reversible_Reactions.ipynb
@@ -63,7 +63,7 @@
    "id": "55c92ce6-985a-463c-a4e7-18b62c8b5de6",
    "metadata": {},
    "source": [
-    "The other reversible reaction notation uses the Rev operator and an example follows bellow "
+    "The other reversible reaction notation uses the Rev operator and an example follows below "
    ]
   },
   {

--- a/docs/example_models/tutorial_notebooks/20_Update_Model_After_Compilation.ipynb
+++ b/docs/example_models/tutorial_notebooks/20_Update_Model_After_Compilation.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "In the previous model, we forgot to add an initial count to the A species and unfortunately set the parameter k_a to zero. \n",
     "The method update_model from the simulation object allows us to correct this. \n",
-    "For each value to be updated, the user must supply a two-element list to the update model function. This two-element list contains in the first index either the meta-species whose initial count will be updated or the parameter whose value will be updated, the second index is the new updated value. Bellow an example follows: "
+    "For each value to be updated, the user must supply a two-element list to the update model function. This two-element list contains in the first index either the meta-species whose initial count will be updated or the parameter whose value will be updated, the second index is the new updated value. Below an example follows: "
    ]
   },
   {

--- a/mobspy/modules/compiler.py
+++ b/mobspy/modules/compiler.py
@@ -130,7 +130,7 @@ class Compiler:
         :param species_counts: (dict) All counts assigned to species in the model
             before the simulation object was constructed
         :param orthogonal_vector_structure: (dict) ref_characteristics_to_objects in other modules. Dictionary
-            with the characteristics as keys and the objects as values. Characteritics pointing to their coordinate
+            with the characteristics as keys and the objects as values. Characteristics pointing to their coordinate
             in the vector space
         :param volume: (int, flot) Simulation volume
         :param type_of_model: (str) deterministic or stochastic

--- a/mobspy/modules/compiler_operator_functions.py
+++ b/mobspy/modules/compiler_operator_functions.py
@@ -45,7 +45,7 @@ def create_all_not_reactions(reactions):
 
 def get_all_non_listed_characteristics(species, characteristics):
     """
-    This function gets all characteristics related to a species except the ones listed bellow.
+    This function gets all characteristics related to a species except the ones listed below.
     It uses inheritance to find all charactersitcs linked to a species
     """
     operator_characteristics = {c for c in characteristics if "$" in c}

--- a/mobspy/modules/function_rate_code.py
+++ b/mobspy/modules/function_rate_code.py
@@ -49,7 +49,7 @@ def extract_reaction_rate(
 
     :param  function_rate_arguments: list of strings of the function rate argument ex:['r1', 'r2', ....]
     :param  combination_of_reactant_species: (list of Species) Meta-species currently being used in this reaction
-    :param  reactant_string_list: (list of strings) list of species strings in order they apear in the reaction
+    :param  reactant_string_list: (list of strings) list of species strings in order they appear in the reaction
     :param  reaction_rate_function: (float, callable, Quantity) rate stored in the reaction object
     :param  dimension: (int) system dimension (for the rate conversion)
 

--- a/mobspy/modules/logic_operator_objects.py
+++ b/mobspy/modules/logic_operator_objects.py
@@ -343,7 +343,7 @@ class MetaSpeciesLogicResolver:
             all individual states
 
         :param characteristics_to_object: orthogonal characteristic space
-        :param to_sort: sort strings or not - so the sum will always apear in the same order
+        :param to_sort: sort strings or not - so the sum will always appear in the same order
         """
         copasi_str = ""
         for i, e in enumerate(self.operation):

--- a/mobspy/modules/logic_operator_objects.py
+++ b/mobspy/modules/logic_operator_objects.py
@@ -35,7 +35,7 @@ class SpeciesComparator:
         :param code_line: (str) line of code to be compiled
         :param line_number: (str) number of the code line currently being compiled
         :param pos: (int) position of the '>' or '<' operator
-        :param symbol: '(' or ')', indicates in which direction the string analysis should proceded
+        :param symbol: '(' or ')', indicates in which direction the string analysis should proceed
         :param number_of_comp: for distinction the default case where only one operator is present
 
         :raise simlog.error: if the code line is not properly written isolating the clauses with parenthesis

--- a/mobspy/modules/meta_class.py
+++ b/mobspy/modules/meta_class.py
@@ -219,7 +219,7 @@ class Reactions:
     @staticmethod
     def __create_reactants_string(list_of_reactants) -> str:
         """
-        Just a simple way to simlog.debug reactions for debbuging
+        Just a simple way to simlog.debug reactions for debugging
         Not relevant for simulation
         Important: here reactants are used interchangeably with products, this works for a list_of_products too
 
@@ -1028,7 +1028,7 @@ class Species(lop_SpeciesComparator, Assignment_Opp_Imp):
         else:
             _logger.error("Only Species and List_Species can be concatenated")
 
-    # Both are defined bellow to be consistent with List_Species behavior
+    # Both are defined below to be consistent with List_Species behavior
     def __iter__(self):
         """
         iter defined to be consistent with List_Species behavior

--- a/mobspy/modules/mobspy_expressions.py
+++ b/mobspy/modules/mobspy_expressions.py
@@ -402,7 +402,7 @@ class ExpressionDefiner:
         This function was implemented as a replacement for innit for classes that inherit from multiple
         Pint objects. This gives the object all the necessary attributes to execute create_from_new_operation.
         I've done this instead of overrinding the __init__ because it had some compatibility issue with Pint
-        __init__ at the time of writting this
+        __init__ at the time of writing this
         """
         # Operation variables
         self._operation = None

--- a/mobspy/modules/order_operators.py
+++ b/mobspy/modules/order_operators.py
@@ -253,7 +253,7 @@ class __Round_Robin_Base(__Operator_Base):
     This is a cycle (round robin) between the reactants to be assigned positions in the product
     The products will keep the characteristics of the reactants except if stated otherwise with .
     For completely new species (no reactant of the same species) we use ALL possible combinations
-    For only the default option see the code bellow
+    For only the default option see the code below
     """
 
     def __call__(

--- a/mobspy/modules/species_string_generator.py
+++ b/mobspy/modules/species_string_generator.py
@@ -23,7 +23,7 @@ def construct_species_char_list(
     spe_or_reactiong_object, characteristics, characteristics_to_object, symbol=None
 ):
     """
-    This function constructs a list in the format ['species_name', 'char1', 'char2', ...]. It generetes this list
+    This function constructs a list in the format ['species_name', 'char1', 'char2', ...]. It generates this list
     for a given meta-species and the specified characteristics. Values of characteristics not specified in a
     particular position are replaced by their default value. If a symbol is given it generates a string from
     the list using the symbol to join it.

--- a/mobspy/parameters/README.md
+++ b/mobspy/parameters/README.md
@@ -1,6 +1,6 @@
 # Parameter Explanation
 
-## Model paramters
+## Model parameters
 
 - `volume` (float w/wo unit): sets the volume in the simulation (default is 1 litre)
 

--- a/mobspy/patch_scripts/basico_task_parametrization.py
+++ b/mobspy/patch_scripts/basico_task_parametrization.py
@@ -1908,7 +1908,7 @@ def save_experiments_to_dict(**kwargs):
     - | `return_relative`: to indicate that relative experiment filenames should
       | be returned (default: True)
 
-    :return: the parameter estimation experimetns as list of dictionary
+    :return: the parameter estimation experiments as list of dictionary
     :rtype: [{}]
     """
     experiments = []

--- a/mobspy/plot_scripts/default_plots.py
+++ b/mobspy/plot_scripts/default_plots.py
@@ -93,7 +93,7 @@ def stochastic_plot(species, data, plot_params):
     new_plot_params["pad"] = 1.5
     color_cycler = hp.Color_cycle()
     for spe in species:
-        # We define new 'mappings' with the resulting runs for the statics for the plot structure
+        # We define new 'mappings' with the resulting runs for the statistics for the plot structure
         try:
             plots_for_spe_i = []
             plots_for_spe_i_sta = []

--- a/mobspy/plot_scripts/hierarchical_plot.py
+++ b/mobspy/plot_scripts/hierarchical_plot.py
@@ -37,7 +37,7 @@ class Color_cycle:
 def find_species_time_series(spe, data):
     """
     There can be different time-series in MobsPy data (even experimental data, as long as it is in MobPy format)
-    This function finds all the time-series the species is present in and returns it for looping thorugh all of
+    This function finds all the time-series the species is present in and returns it for looping through all of
     them
     This function is implemented to allow for the comparison of models with experimental data or other models
 

--- a/mobspy/plot_scripts/hierarchical_plot.py
+++ b/mobspy/plot_scripts/hierarchical_plot.py
@@ -70,7 +70,7 @@ def get_total_figure_number(axis_matrix):
 # Hash for converting linear figure number into index
 def figure_hash(current_figure, axis_matrix):
     """
-    This function allows one to acess the figure grid with a linear input
+    This function allows one to access the figure grid with a linear input
     For instance one can access a 2x2 grid using 0, 1, 2, 3
     0 becomes 0,0
     1 becomes 1,0
@@ -222,7 +222,7 @@ def annotation_handling(axs, figure_index, plot_index, plot_params):
             return 0
 
 
-####################### PLOTING FUNCTIONS
+####################### PLOTTING FUNCTIONS
 def plot_curves(data, axs, figure_index, plot_params):
     """
     This function plots the programmed curves in the assigned figure

--- a/mobspy/sbml_simulator/run.py
+++ b/mobspy/sbml_simulator/run.py
@@ -97,7 +97,7 @@ def job_execution(params, models, jobs):
     if not parallel_data:
         simlog.error(
             "Error: The parallel model has not produced an output."
-            + "Try addding ('sequential': True) to parameters"
+            + "Try adding ('sequential': True) to parameters"
         )
 
     return parallel_data

--- a/mobspy/simulation.py
+++ b/mobspy/simulation.py
@@ -1590,7 +1590,7 @@ class SimulationComposition:
 
         :param duration: (iterable) duration of a simulation
         :param volume: (iterable) volume of the simulation - if none given 1 - liter is used
-        :param repetitions: (int) number of times to reapeat a simulation
+        :param repetitions: (int) number of times to repeat a simulation
         :param level: (int) 0 - only error messages, 3 - errors, warnings, compilation info
         :param simulation_method: (iterable) stochastic, deterministic, direct_method - simulation method
         :param start_time: (float) the simulation will only display data after the start time


### PR DESCRIPTION
Add [codespell](https://github.com/codespell-project/codespell) configuration, a GitHub Actions workflow that runs it on every push and PR, and fix the existing typos it detected.

I've personally introduced codespell to over a hundred of projects already mostly with positive feedback (see the ["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md) for an example summary). The CI workflow has `permissions: contents: read` and uses a pinned action SHA, so it should be safe.

## Changes

### Configuration & Infrastructure
- `.codespellrc` with skip patterns (`.git`, `.git-meta`, `.gitignore`, `.gitattributes`, `*.svg`, `.codespellrc`), `check-hidden = true`, and an `ignore-regex` that skips embedded base64 images in notebook JSON.
- `.github/workflows/codespell.yml` — runs codespell on push and PRs to `main`, pinned to `codespell-project/actions-codespell@8f01853...` (v2.2).

### Domain whitelist
- `inactivate` — added to `ignore-words-list` because it is a valid English (and biology) term used in `docs/example_models/application_models/NOR_gate.py` ("any of them can inactivate the Promoter"). Codespell incorrectly suggested replacing it with "deactivate".

### Typo fixes

**Ambiguous (manually fixed with context review)** — 2 fixes:
- `proceded` → `proceed` in `mobspy/modules/logic_operator_objects.py:38` (auxiliary "should" + infinitive: "string analysis should proceed")
- `thorugh` → `through` in `mobspy/plot_scripts/hierarchical_plot.py:40` (preposition: "looping through all of them")

**Non-ambiguous (applied automatically via `codespell -w`)** — 26 fixes across 21 files. Common ones:
- `bellow` → `below` (5×)
- `acess` → `access` (3×)
- `apear` → `appear` (2×)
- `Indepedent` → `Independent`, `Futhermore` → `Furthermore`, `conterparts` → `counterparts`
- `charcteristic`, `characteritics`, `Characteritics` → `character(istic[s])`
- `reapeat` → `repeat`, `debbuging` → `debugging`, `writting` → `writing`
- `generetes` → `generates`, `paramters` → `parameters`, `experimetns` → `experiments`
- `statics` → `statistics` (in a comment only; the variable `plots_for_spe_i_sta` is unchanged)
- `PLOTING` → `PLOTTING`, `addding` → `adding`

All fixes are in comments, docstrings, markdown cells, and section headers. No regex patterns, variable names, or code identifiers were modified.

### Historical context
There have been a handful of prior commits in this repo manually fixing typos (`607b3f3`, `30527eb`, `ae895e6`, `0a18615`), which is exactly the kind of churn an automated check eliminates going forward.

## Testing

- `uvx codespell` passes with exit code 0 after all fixes.
- All non-ambiguous fixes were produced by `codespell -w` wrapped in `datalad run`, so the exact command is recorded in the commit metadata and can be re-run with `datalad rerun`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typo-free code
